### PR TITLE
Feature/link

### DIFF
--- a/API_Enhanced_City/api/web_api.py
+++ b/API_Enhanced_City/api/web_api.py
@@ -393,7 +393,7 @@ def create_link(target_type_name):
     if source_id is None or target_id is None:
         raise BadRequest('Missing source and/or target id')
     link = LinkController.create_link(target_type_name, source_id, target_id)
-    return ResponseOK(link)
+    return ResponseCreated(link)
 
 
 if __name__ == '__main__':

--- a/API_Enhanced_City/api/web_api.py
+++ b/API_Enhanced_City/api/web_api.py
@@ -12,6 +12,7 @@ from controller.TourController import TourController
 from controller.UserController import UserController
 from controller.DocController import DocController
 from controller.ArchiveController import ArchiveController
+from controller.LinkController import LinkController
 from util.upload import *
 from util.JsonCustomEncoder import JsonCustomEncoder
 
@@ -347,6 +348,52 @@ def update_guided_tour_document(tour_id, doc_position):
 def delete_guided_tour_document(tour_id, doc_position):
     updated_tour = TourController.remove_document(tour_id, doc_position)
     return ResponseOK(updated_tour)
+
+# ---- LINKS -------------------------------------------------------------------
+
+
+@app.route('/link', methods=['GET'])
+@format_response
+def get_link_target_types():
+    """
+    Retrieves all supported target type names.
+    :return: All supported target type names.
+    """
+    types = LinkController.get_target_types()
+    return ResponseOK(types)
+
+
+@app.route('/link/<target_type_name>', methods=['GET'])
+@format_response
+def get_links(target_type_name):
+    """
+    Retrieves links between documents and the specified target type.
+
+    :param str target_type_name: Name of the target type. Accepted names are :
+        'city_object'.
+    :return: The retrieved links
+    """
+    filters = request.form
+    links = LinkController.get_links(target_type_name, filters)
+    return ResponseOK(links)
+
+
+@app.route('/link/<target_type_name>', methods=['POST'])
+@format_response
+def create_link(target_type_name):
+    """
+    Creates a new link between the source document and the specified target.
+
+    :param target_type_name: Name of the target type. Accepted names are :
+        'city_object'.
+    :return: The newly created link
+    """
+    source_id = request.form.get('source_id')
+    target_id = request.form.get('target_id')
+    if source_id is None or target_id is None:
+        raise BadRequest('Missing source and/or target id')
+    link = LinkController.create_link(target_type_name, source_id, target_id)
+    return ResponseOK(link)
 
 
 if __name__ == '__main__':

--- a/API_Enhanced_City/clear-db.sh
+++ b/API_Enhanced_City/clear-db.sh
@@ -1,0 +1,2 @@
+rm -r ./postgres-data/
+rm ./upload/*

--- a/API_Enhanced_City/controller/Controller.py
+++ b/API_Enhanced_City/controller/Controller.py
@@ -16,6 +16,7 @@ from entities.VersionDoc import VersionDoc
 from entities.DocumentUser import DocumentUser
 from entities.ValidationStatus import ValidationStatus
 from entities.Visualisation import Visualisation
+from entities.LinkCityObject import LinkCityObject
 
 
 class Controller:

--- a/API_Enhanced_City/controller/Controller.py
+++ b/API_Enhanced_City/controller/Controller.py
@@ -4,10 +4,10 @@
 from util.db_config import *
 import persistence_unit.PersistenceUnit as pUnit
 from controller.UserController import UserController
-from controller.PositionController import PositionController
+from controller.UserRoleController import UserRoleController
 
 from entities.User import User
-from entities.Position import Position
+from entities.UserRole import UserRole
 from entities.GuidedTour import GuidedTour
 from entities.Document import Document
 from entities.DocumentGuidedTour import DocumentGuidedTour
@@ -36,5 +36,5 @@ class Controller:
     @staticmethod
     def create_tables():
         Base.metadata.create_all(pUnit.engine)
-        PositionController.create_all_positions()
+        UserRoleController.create_all_roles()
         UserController.create_admin()

--- a/API_Enhanced_City/controller/LinkController.py
+++ b/API_Enhanced_City/controller/LinkController.py
@@ -1,0 +1,89 @@
+from typing import Type, Dict
+
+from sqlalchemy.orm.session import Session
+
+from util.Exception import BadRequest
+
+from entities.LinkCityObject import LinkCityObject
+
+import persistence_unit.PersistenceUnit as pUnit
+
+
+class LinkController:
+    """
+    Controller used to manage links. For the moment, only links with city
+    objects are handled.
+
+    LinkController works in a generic way to handle all types of links, without
+    the need to add specific code for each type. Two methods are supported to
+    get and create links :
+
+    - `get_links` : retrieve all links of a specified type. The type is passed
+      as the `target_type_name` parameter. A `filters` dict can be also passed
+      as parameter to filter results by source and/or target ids.
+    - `create_link` : creates a new link of the specified type. The type is
+      passed as the `target_type_name` parameter. The parameters `source_id` and
+      `target_id` are mandatory.
+
+    `target_type_name` refers to a string representing a possibly target type
+    for a link. These strings are specified in the `target_types` dictionary as
+    keys, where the values correspond to the entity class type. Possible target
+    type names can be retrieved with the `get_target_types` function.
+    """
+
+    target_types: Dict[str, Type[LinkCityObject]] = {
+        'city_object': LinkCityObject
+    }
+
+    @staticmethod
+    def get_target_types():
+        """
+        Returns all supported target type names.
+        :return: All supported target type names.
+        """
+        return list(LinkController.target_types.keys())
+
+    @staticmethod
+    @pUnit.make_a_query
+    def get_links(session, target_type_name, filters={}):
+        """
+        Retrieve all links related to the target type.
+
+        :param Session session: SQLAlchemy session (auto filled)
+        :param str target_type_name: The name of the target type.
+        :param dict filters: A dict to specify either the source or the target
+            of the link. Two keys are accepted : `source_id` and `target_id`. If
+            none is provided, no filtering is performed and all links of this type
+            are retrieved.
+        :return: All links retrieved.
+        """
+        target_type = LinkController.target_types.get(target_type_name)
+        if target_type is None:
+            raise BadRequest(f'{target_type_name} is not a valid link target.')
+        source_id = filters.get('source_id')
+        target_id = filters.get('target_id')
+        query = session.query(target_type)
+        if source_id is not None:
+            query = query.filter(target_type.source_id == source_id)
+        if target_id is not None:
+            query = query.filter(target_type.target_id == target_id)
+        return query.all()
+
+    @staticmethod
+    @pUnit.make_a_transaction
+    def create_link(session, target_type_name, source_id, target_id):
+        """
+        Creates a link between the given document and city objects.
+
+        :param Session session: SQLAlchemy session (auto filled)
+        :param str target_type_name: The name of the target type.
+        :param int source_id: ID of the source document.
+        :param any target_id: ID of the target city object.
+        :return: The newly created link.
+        """
+        target_type = LinkController.target_types.get(target_type_name)
+        if target_type is None:
+            raise BadRequest(f'{target_type_name} is not a valid link target.')
+        new_link = target_type(source_id, target_id)
+        session.add(new_link)
+        return new_link

--- a/API_Enhanced_City/controller/UserController.py
+++ b/API_Enhanced_City/controller/UserController.py
@@ -7,7 +7,7 @@ from util.Exception import Unauthorized
 from util.encryption import *
 from util.log import info_logger
 from entities.User import User
-from entities.Position import Position
+from entities.UserRole import UserRole
 import persistence_unit.PersistenceUnit as pUnit
 
 
@@ -26,8 +26,8 @@ class UserController:
     def create_user(session, *args):
         attributes = args[0]
         user = User()
-        user.set_position(session.query(Position).filter(
-            Position.label == Position.get_clearance(0)).one())
+        user.set_role(session.query(UserRole).filter(
+            UserRole.label == UserRole.get_clearance(0)).one())
         user.update(attributes)
         session.add(user)
         return user
@@ -39,7 +39,7 @@ class UserController:
         payload = args[1]
         if User.is_admin(attributes):
             user = User()
-            user.set_position(session.query(Position).filter(Position.label == attributes["role"]).one())
+            user.set_role(session.query(UserRole).filter(UserRole.label == attributes["role"]).one())
             user.update(attributes)
             session.add(user)
             return user
@@ -51,8 +51,8 @@ class UserController:
     def create_admin_user(session, *args):
         attributes = args[0]
         user = User()
-        user.set_position(session.query(Position).filter(Position.label == attributes["role"]).one())
         user.update(attributes)
+        user.set_role(session.query(UserRole).filter(UserRole.label == attributes["role"]).one())
         session.add(user)
         return user
 
@@ -81,7 +81,7 @@ class UserController:
                     'firstName': user.firstName,
                     'lastName': user.lastName,
                     'email': user.email,
-                    'position': user.position.serialize(),
+                    'role': user.role.serialize(),
                     'exp': exp
                 }
                 return {

--- a/API_Enhanced_City/controller/UserRoleController.py
+++ b/API_Enhanced_City/controller/UserRoleController.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 # coding: utf8
 
-from entities.Position import Position
+from entities.UserRole import UserRole
 import persistence_unit.PersistenceUnit as pUnit
 
 
-class PositionController:
+class UserRoleController:
     """
     Class that allows communication with the DB
     No instance is needed because all its methods are static.
@@ -17,22 +17,22 @@ class PositionController:
 
     @staticmethod
     @pUnit.make_a_query
-    def get_positions(session):
-        return session.query(Position).all()
+    def get_roles(session):
+        return session.query(UserRole).all()
 
     @staticmethod
     @pUnit.make_a_transaction
-    def create_position(session, label):
-        position_exist = session.query(Position).filter(
-            Position.label == label).scalar() is not None
+    def create_role(session, label):
+        position_exist = session.query(UserRole).filter(
+            UserRole.label == label).scalar() is not None
 
         if not position_exist:
-            position = Position(label)
+            position = UserRole(label)
             session.add(position)
 
     @staticmethod
-    def create_all_positions():
-        PositionController.create_position("admin")
-        PositionController.create_position("moderator")
-        PositionController.create_position("softModerator")
-        PositionController.create_position("contributor")
+    def create_all_roles():
+        UserRoleController.create_role("admin")
+        UserRoleController.create_role("moderator")
+        UserRoleController.create_role("softModerator")
+        UserRoleController.create_role("contributor")

--- a/API_Enhanced_City/doc/Links.md
+++ b/API_Enhanced_City/doc/Links.md
@@ -1,0 +1,41 @@
+# Link management
+
+## Entities
+
+A conceptual link should represent a relationship between a document and any linkable object. To represent this 
+concept in the database, we decided to create as many `Link` entities as there are types of linkable objects.
+
+For the moment, the only linkable object implemented is the "city object". The link are stored in the database thanks
+ to `LinkCityObject` entities.
+ 
+## Controller
+
+Whereas each linkable object is represented by a distinct entity in the database, a generic controller is used to 
+manage every type of links.
+
+The following text is taken from the docstring of the class :
+
+> `LinkController` works in a generic way to handle all types of links, without
+> the need to add specific code for each type. Two methods are supported to
+> get and create links :
+> 
+> - `get_links` : retrieve all links of a specified type. The type is passed as the `target_type_name` parameter. A 
+> `filters` dict can be also passed as parameter to filter results by source and/or target ids.
+> - `create_link` : creates a new link of the specified type. The type is passed as the `target_type_name` parameter. 
+> The parameters `source_id` and `target_id` are mandatory.
+> 
+> `target_type_name` refers to a string representing a possibly target type
+> for a link. These strings are specified in the `target_types` dictionary as
+> keys, where the values correspond to the entity class type. Possible target
+> type names can be retrieved with the `get_target_types` function.
+
+## Routes
+
+Three routes are provided by the API to access and create links :
+
+- `GET /link` returns all target types supported.
+- `GET /link/<target_type>` returns all links of a given target type. Links can be filtered depending on their source
+ or their target.
+ - `POST /link/<target_type>` creates and return a new link between the specified source and target.
+
+More detailed documentation for the routes is available on the OpenAPI specification (under the `OpenAPI2` folder).

--- a/API_Enhanced_City/doc/OpenAPI2/swagger.json
+++ b/API_Enhanced_City/doc/OpenAPI2/swagger.json
@@ -1,1433 +1,1808 @@
 {
-  "swagger" : "2.0",
-  "info" : {
-    "description" : "API used to manage the extended documents in UDV Server.",
-    "version" : "1.0.0",
-    "title" : "UDV-Server API$"
+  "swagger": "2.0",
+  "info": {
+    "description": "API used to manage the extended documents in UDV Server.",
+    "version": "1.0.0",
+    "title": "UDV-Server API$"
   },
-  "host" : "virtserver.swaggerhub.com",
-  "basePath" : "/Crejak/UDV-Server/1.0.0",
-  "tags" : [ {
-    "name" : "Users",
-    "description" : "User account management"
-  }, {
-    "name" : "Documents",
-    "description" : "Extended documents management"
-  }, {
-    "name" : "Document files",
-    "description" : "Management of files attached to extended documents"
-  }, {
-    "name" : "Document validation",
-    "description" : "Management of documents in validation"
-  }, {
-    "name" : "Document comments",
-    "description" : "Management of comments attached to extended documents"
-  }, {
-    "name" : "Document archives",
-    "description" : "Management of previous versions of extended documents"
-  }, {
-    "name" : "Guided tours",
-    "description" : "Guided tour management"
-  }, {
-    "name" : "Guided tour documents",
-    "description" : "Management of documents inside a guided tour"
-  } ],
-  "schemes" : [ "https" ],
-  "paths" : {
-    "/login" : {
-      "post" : {
-        "tags" : [ "Users" ],
-        "summary" : "Log in and retrieve a token",
-        "description" : "Authenticate a user by giving them a auth token",
-        "consumes" : [ "multipart/form-data" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "username",
-          "in" : "formData",
-          "description" : "Username of the user",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "password",
-          "in" : "formData",
-          "description" : "Password of the user",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully logged in",
-            "schema" : {
-              "$ref" : "#/definitions/TokenItem"
+  "host": "localhost:5000",
+  "tags": [
+    {
+      "name": "Users",
+      "description": "User account management"
+    },
+    {
+      "name": "Documents",
+      "description": "Extended documents management"
+    },
+    {
+      "name": "Document files",
+      "description": "Management of files attached to extended documents"
+    },
+    {
+      "name": "Document validation",
+      "description": "Management of documents in validation"
+    },
+    {
+      "name": "Document comments",
+      "description": "Management of comments attached to extended documents"
+    },
+    {
+      "name": "Document archives",
+      "description": "Management of previous versions of extended documents"
+    },
+    {
+      "name": "Guided tours",
+      "description": "Guided tour management"
+    },
+    {
+      "name": "Guided tour documents",
+      "description": "Management of documents inside a guided tour"
+    },
+    {
+      "name": "Links",
+      "description": "Management of links between documents and likable objects"
+    }
+  ],
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/login": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Log in and retrieve a token",
+        "description": "Authenticate a user by giving them a auth token",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "formData",
+            "description": "Username of the user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "formData",
+            "description": "Password of the user",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully logged in",
+            "schema": {
+              "$ref": "#/definitions/TokenItem"
             }
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     },
-    "/user" : {
-      "post" : {
-        "tags" : [ "Users" ],
-        "summary" : "Create a new user",
-        "description" : "Add a new User by passing informations below\n",
-        "consumes" : [ "multipart/form-data" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "lastName",
-          "in" : "formData",
-          "description" : "Pass the lastName of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "firstName",
-          "in" : "formData",
-          "description" : "Pass the firstName of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "email",
-          "in" : "formData",
-          "description" : "Pass the email of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "username",
-          "in" : "formData",
-          "description" : "Pass the username of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "password",
-          "in" : "formData",
-          "description" : "Pass the password of user you want to create",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "201" : {
-            "description" : "Information about the new user",
-            "schema" : {
-              "$ref" : "#/definitions/UserItem"
+    "/user": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Create a new user",
+        "description": "Add a new User by passing informations below\n",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "lastName",
+            "in": "formData",
+            "description": "Pass the lastName of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "firstName",
+            "in": "formData",
+            "description": "Pass the firstName of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "email",
+            "in": "formData",
+            "description": "Pass the email of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "username",
+            "in": "formData",
+            "description": "Pass the username of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "formData",
+            "description": "Pass the password of user you want to create",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Information about the new user",
+            "schema": {
+              "$ref": "#/definitions/UserItem"
             }
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     },
-    "/user/me" : {
-      "get" : {
-        "tags" : [ "Users" ],
-        "summary" : "Retrieve the connected user",
-        "description" : "Retrieve the logged in user with the given token\n",
-        "produces" : [ "application/json" ],
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "The connected user's information",
-            "schema" : {
-              "$ref" : "#/definitions/UserItem"
+    "/user/me": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Retrieve the connected user",
+        "description": "Retrieve the logged in user with the given token\n",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The connected user's information",
+            "schema": {
+              "$ref": "#/definitions/UserItem"
             }
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
-    "/user/{id}" : {
-      "get" : {
-        "tags" : [ "Users" ],
-        "summary" : "Retrieve user by their ID",
-        "description" : "Retrieve a specific User by passing the id\n",
-        "consumes" : [ "multipart/form-data" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "Pass the id of user you want to retrieve",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The user's information",
-            "schema" : {
-              "$ref" : "#/definitions/UserItem"
+    "/user/{id}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Retrieve user by their ID",
+        "description": "Retrieve a specific User by passing the id\n",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Pass the id of user you want to retrieve",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The user's information",
+            "schema": {
+              "$ref": "#/definitions/UserItem"
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     },
-    "/user/grant" : {
-      "post" : {
-        "tags" : [ "Users" ],
-        "summary" : "Create a privileged user",
-        "description" : "Create a user with the specific role",
-        "consumes" : [ "multipart/form-data" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "lastName",
-          "in" : "formData",
-          "description" : "Pass the lastName of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "firstName",
-          "in" : "formData",
-          "description" : "Pass the firstName of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "email",
-          "in" : "formData",
-          "description" : "Pass the email of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "username",
-          "in" : "formData",
-          "description" : "Pass the username of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "password",
-          "in" : "formData",
-          "description" : "Pass the password of user you want to create",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "role",
-          "in" : "formData",
-          "description" : "The role of the user",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The user's information",
-            "schema" : {
-              "$ref" : "#/definitions/UserItem"
+    "/user/grant": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Create a privileged user",
+        "description": "Create a user with the specific role",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "lastName",
+            "in": "formData",
+            "description": "Pass the lastName of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "firstName",
+            "in": "formData",
+            "description": "Pass the firstName of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "email",
+            "in": "formData",
+            "description": "Pass the email of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "username",
+            "in": "formData",
+            "description": "Pass the username of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "formData",
+            "description": "Pass the password of user you want to create",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "role",
+            "in": "formData",
+            "description": "The role of the user",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The user's information",
+            "schema": {
+              "$ref": "#/definitions/UserItem"
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
-    "/document" : {
-      "get" : {
-        "tags" : [ "Documents" ],
-        "summary" : "Get all extended documents",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully get the extended documents",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ExtendedDocument"
+    "/document": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Get all extended documents",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully get the extended documents",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExtendedDocument"
               }
             }
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "post" : {
-        "tags" : [ "Documents" ],
-        "summary" : "Create a new extended document",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "title",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "subject",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "description",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "refDate",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "publicationDate",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "type",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "quaternionX",
-          "in" : "formData",
-          "required" : true,
-          "type" : "number"
-        }, {
-          "name" : "quaternionY",
-          "in" : "formData",
-          "required" : true,
-          "type" : "number"
-        }, {
-          "name" : "quaternionZ",
-          "in" : "formData",
-          "required" : true,
-          "type" : "number"
-        }, {
-          "name" : "quaternionW",
-          "in" : "formData",
-          "required" : true,
-          "type" : "number"
-        }, {
-          "name" : "positionX",
-          "in" : "formData",
-          "required" : true,
-          "type" : "number"
-        }, {
-          "name" : "positionY",
-          "in" : "formData",
-          "required" : true,
-          "type" : "number"
-        }, {
-          "name" : "positionZ",
-          "in" : "formData",
-          "required" : true,
-          "type" : "number"
-        }, {
-          "name" : "file",
-          "in" : "formData",
-          "required" : true,
-          "type" : "file"
-        } ],
-        "responses" : {
-          "201" : {
-            "description" : "Successfully created an extended document",
-            "schema" : {
-              "$ref" : "#/definitions/ExtendedDocument"
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Create a new extended document",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "title",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subject",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "refDate",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "publicationDate",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "quaternionX",
+            "in": "formData",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "quaternionY",
+            "in": "formData",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "quaternionZ",
+            "in": "formData",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "quaternionW",
+            "in": "formData",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "positionX",
+            "in": "formData",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "positionY",
+            "in": "formData",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "positionZ",
+            "in": "formData",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully created an extended document",
+            "schema": {
+              "$ref": "#/definitions/ExtendedDocument"
             }
           },
-          "400" : {
-            "description" : "Request is malformed (a mandatory field is missing)"
+          "400": {
+            "description": "Request is malformed (a mandatory field is missing)"
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "415" : {
-            "description" : "The file has an incorrect format\n"
+          "415": {
+            "description": "The file has an incorrect format\n"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
-    "/document/{id}" : {
-      "get" : {
-        "tags" : [ "Documents" ],
-        "summary" : "Get an extended document with a specific id",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the extendedDoc.",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully get the extendedDoc",
-            "schema" : {
-              "$ref" : "#/definitions/ExtendedDocument"
+    "/document/{id}": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Get an extended document with a specific id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the extendedDoc.",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully get the extendedDoc",
+            "schema": {
+              "$ref": "#/definitions/ExtendedDocument"
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "put" : {
-        "tags" : [ "Documents" ],
-        "summary" : "Update an extended document",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the document.",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "title",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "subject",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "description",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "refDate",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "publicationDate",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "type",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "quaternionX",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "quaternionY",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "quaternionZ",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "quaternionW",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "positionX",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "positionY",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "positionZ",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully updated the document",
-            "schema" : {
-              "$ref" : "#/definitions/ExtendedDocument"
+      "put": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Update an extended document",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the document.",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          },
+          {
+            "name": "title",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "subject",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "refDate",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "publicationDate",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "quaternionX",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "quaternionY",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "quaternionZ",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "quaternionW",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "positionX",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "positionY",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "positionZ",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated the document",
+            "schema": {
+              "$ref": "#/definitions/ExtendedDocument"
             }
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       },
-      "delete" : {
-        "tags" : [ "Documents" ],
-        "summary" : "Delete an extended document with a specific id",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the document.",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully deleted the document",
-            "schema" : {
-              "$ref" : "#/definitions/ExtendedDocument"
+      "delete": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Delete an extended document with a specific id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the document.",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted the document",
+            "schema": {
+              "$ref": "#/definitions/ExtendedDocument"
             }
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
-    "/document/{id}/file" : {
-      "get" : {
-        "tags" : [ "Document files" ],
-        "summary" : "Get the file associated to a document",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the extendedDoc.",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully get the document's image with the specified id\n"
+    "/document/{id}/file": {
+      "get": {
+        "tags": [
+          "Document files"
+        ],
+        "summary": "Get the file associated to a document",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the extendedDoc.",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully get the document's image with the specified id\n"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "post" : {
-        "tags" : [ "Document files" ],
-        "summary" : "Upload and associate a file to document",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the document",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "file",
-          "in" : "formData",
-          "description" : "The file to upload",
-          "required" : true,
-          "type" : "file"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully uploaded the document's file"
+      "post": {
+        "tags": [
+          "Document files"
+        ],
+        "summary": "Upload and associate a file to document",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the document",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "The file to upload",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully uploaded the document's file"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
+          },
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       },
-      "delete" : {
-        "tags" : [ "Document files" ],
-        "summary" : "Delete the file associated to a document",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the extendedDoc.",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "Successfully delete the extendedDocument file"
+      "delete": {
+        "tags": [
+          "Document files"
+        ],
+        "summary": "Delete the file associated to a document",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the extendedDoc.",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully delete the extendedDocument file"
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
-    "/document/in_validation" : {
-      "get" : {
-        "tags" : [ "Document validation" ],
-        "summary" : "Get the documents in validation",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "The retrieved documents",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ExtendedDocument"
+    "/document/in_validation": {
+      "get": {
+        "tags": [
+          "Document validation"
+        ],
+        "summary": "Get the documents in validation",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The retrieved documents",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExtendedDocument"
               }
             }
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
-    "/document/validate" : {
-      "post" : {
-        "tags" : [ "Document validation" ],
-        "summary" : "Validate a document",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "formData",
-          "description" : "ID of the extended document in validation",
-          "required" : true,
-          "type" : "integer"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfuly validated the document"
+    "/document/validate": {
+      "post": {
+        "tags": [
+          "Document validation"
+        ],
+        "summary": "Validate a document",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "formData",
+            "description": "ID of the extended document in validation",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfuly validated the document"
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
-    "/document/{id}/comment" : {
-      "get" : {
-        "tags" : [ "Document comments" ],
-        "summary" : "Get all the comments associated to a document",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the extendedDoc.",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The retrieved comments for this document",
-            "schema" : {
-              "$ref" : "#/definitions/Comment"
+    "/document/{id}/comment": {
+      "get": {
+        "tags": [
+          "Document comments"
+        ],
+        "summary": "Get all the comments associated to a document",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the extendedDoc.",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved comments for this document",
+            "schema": {
+              "$ref": "#/definitions/Comment"
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "post" : {
-        "tags" : [ "Document comments" ],
-        "summary" : "Create a new comment, associated to a document",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the extendedDoc.",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "description",
-          "in" : "formData",
-          "description" : "Comment",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "201" : {
-            "description" : "Successfully create a new comment, associated to a document",
-            "schema" : {
-              "$ref" : "#/definitions/Comment"
+      "post": {
+        "tags": [
+          "Document comments"
+        ],
+        "summary": "Create a new comment, associated to a document",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the extendedDoc.",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "description": "Comment",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully create a new comment, associated to a document",
+            "schema": {
+              "$ref": "#/definitions/Comment"
             }
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
-    "/comment/{id}" : {
-      "get" : {
-        "tags" : [ "Document comments" ],
-        "summary" : "Get a specific comment",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the comment",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The retrieved comment",
-            "schema" : {
-              "$ref" : "#/definitions/Comment"
+    "/comment/{id}": {
+      "get": {
+        "tags": [
+          "Document comments"
+        ],
+        "summary": "Get a specific comment",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the comment",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved comment",
+            "schema": {
+              "$ref": "#/definitions/Comment"
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "put" : {
-        "tags" : [ "Document comments" ],
-        "summary" : "Modify a comment",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the comment",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "description",
-          "in" : "formData",
-          "description" : "Content of the comment",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully updated the comment",
-            "schema" : {
-              "$ref" : "#/definitions/Comment"
+      "put": {
+        "tags": [
+          "Document comments"
+        ],
+        "summary": "Modify a comment",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the comment",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "description": "Content of the comment",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated the comment",
+            "schema": {
+              "$ref": "#/definitions/Comment"
             }
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         },
-        "security" : [ {
-          "Bearer" : [ ]
-        } ]
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       },
-      "delete" : {
-        "tags" : [ "Document comments" ],
-        "summary" : "Delete a comment",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the comment",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully deleted the comment",
-            "schema" : {
-              "$ref" : "#/definitions/Comment"
+      "delete": {
+        "tags": [
+          "Document comments"
+        ],
+        "summary": "Delete a comment",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the comment",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted the comment",
+            "schema": {
+              "$ref": "#/definitions/Comment"
             }
           },
-          "401" : {
-            "description" : "Authentication is needed to perform the request"
+          "401": {
+            "description": "Authentication is needed to perform the request"
           },
-          "403" : {
-            "description" : "The user does not has sufficient privilege to perform the request\n"
+          "403": {
+            "description": "The user does not has sufficient privilege to perform the request\n"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     },
-    "/document/{id}/archive" : {
-      "get" : {
-        "tags" : [ "Document archives" ],
-        "summary" : "Get all previous versions of a document with a specific ID",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the document",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The successfully retrieved versions",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ExtendedDocument"
+    "/document/{id}/archive": {
+      "get": {
+        "tags": [
+          "Document archives"
+        ],
+        "summary": "Get all previous versions of a document with a specific ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the document",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The successfully retrieved versions",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExtendedDocument"
               }
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     },
-    "/guidedTour" : {
-      "get" : {
-        "tags" : [ "Guided tours" ],
-        "summary" : "Get all guided tours",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "The guided tours",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/GuidedTour"
+    "/guidedTour": {
+      "get": {
+        "tags": [
+          "Guided tours"
+        ],
+        "summary": "Get all guided tours",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The guided tours",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GuidedTour"
               }
             }
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "post" : {
-        "tags" : [ "Guided tours" ],
-        "summary" : "Create a new guided tour",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "description",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "201" : {
-            "description" : "Successfully created a guided tour",
-            "schema" : {
-              "$ref" : "#/definitions/GuidedTour"
+      "post": {
+        "tags": [
+          "Guided tours"
+        ],
+        "summary": "Create a new guided tour",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully created a guided tour",
+            "schema": {
+              "$ref": "#/definitions/GuidedTour"
             }
           },
-          "400" : {
-            "description" : "Request is malformed (a mandatory field is missing)"
+          "400": {
+            "description": "Request is malformed (a mandatory field is missing)"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     },
-    "/guidedTour/{id}" : {
-      "get" : {
-        "tags" : [ "Guided tours" ],
-        "summary" : "Get a guided tour with the specified ID",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the guided tour",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The retrieved guided tour",
-            "schema" : {
-              "$ref" : "#/definitions/GuidedTour"
+    "/guidedTour/{id}": {
+      "get": {
+        "tags": [
+          "Guided tours"
+        ],
+        "summary": "Get a guided tour with the specified ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the guided tour",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved guided tour",
+            "schema": {
+              "$ref": "#/definitions/GuidedTour"
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "put" : {
-        "tags" : [ "Guided tours" ],
-        "summary" : "Update a guidedTour with a specific id",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the guided tour",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "name",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "description",
-          "in" : "formData",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The updated guided tour",
-            "schema" : {
-              "$ref" : "#/definitions/GuidedTour"
+      "put": {
+        "tags": [
+          "Guided tours"
+        ],
+        "summary": "Update a guidedTour with a specific id",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the guided tour",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated guided tour",
+            "schema": {
+              "$ref": "#/definitions/GuidedTour"
             }
           },
-          "400" : {
-            "description" : "Request is malformed (a mandatory field is missing)"
+          "400": {
+            "description": "Request is malformed (a mandatory field is missing)"
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "delete" : {
-        "tags" : [ "Guided tours" ],
-        "summary" : "Delete a guidedTour with a specific id",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the guided tour",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The deleted guided tour",
-            "schema" : {
-              "$ref" : "#/definitions/GuidedTour"
+      "delete": {
+        "tags": [
+          "Guided tours"
+        ],
+        "summary": "Delete a guidedTour with a specific id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the guided tour",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The deleted guided tour",
+            "schema": {
+              "$ref": "#/definitions/GuidedTour"
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     },
-    "/guidedTour/{id}/document" : {
-      "post" : {
-        "tags" : [ "Guided tour documents" ],
-        "summary" : "Add a dcoument to a guided tour",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the guided tour",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "user_id",
-          "in" : "formData",
-          "description" : "ID of the document to add",
-          "required" : true,
-          "type" : "number"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully add a document to a guded tour"
+    "/guidedTour/{id}/document": {
+      "post": {
+        "tags": [
+          "Guided tour documents"
+        ],
+        "summary": "Add a dcoument to a guided tour",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the guided tour",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          {
+            "name": "doc_id",
+            "in": "formData",
+            "description": "ID of the document to add",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully add a document to a guded tour"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
+          },
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     },
-    "/guidedTour/{id}/document/{doc_id}" : {
-      "put" : {
-        "tags" : [ "Guided tour documents" ],
-        "summary" : "Modify a document associated to a guided tour",
-        "consumes" : [ "multipart/form-data" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the guided tour",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "doc_id",
-          "in" : "path",
-          "description" : "Position of the document in the guided tour. This is not the ID of the document\n",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "text1",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "text2",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "title",
-          "in" : "formData",
-          "required" : false,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The successfully updated guided tour",
-            "schema" : {
-              "$ref" : "#/definitions/GuidedTour"
+    "/guidedTour/{id}/document/{doc_id}": {
+      "put": {
+        "tags": [
+          "Guided tour documents"
+        ],
+        "summary": "Modify a document associated to a guided tour",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the guided tour",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          },
+          {
+            "name": "doc_id",
+            "in": "path",
+            "description": "Position of the document in the guided tour. This is not the ID of the document\n",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          },
+          {
+            "name": "text1",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "text2",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "title",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The successfully updated guided tour",
+            "schema": {
+              "$ref": "#/definitions/GuidedTour"
             }
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          "404": {
+            "description": "The specified resource was not found"
           },
-          "422" : {
-            "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+          "422": {
+            "description": "Unprocessable entity (invalid field, duplicate item)\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       },
-      "delete" : {
-        "tags" : [ "Guided tour documents" ],
-        "summary" : "Delete the document associated to a guided tour",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "ID of the guided tour",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        }, {
-          "name" : "doc_id",
-          "in" : "path",
-          "description" : "Position of the document in the guided tour. This is not the ID of the document\n",
-          "required" : true,
-          "type" : "integer",
-          "x-example" : 1
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The successfully deleted document, associated to the guided tour.\n"
+      "delete": {
+        "tags": [
+          "Guided tour documents"
+        ],
+        "summary": "Delete the document associated to a guided tour",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the guided tour",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
           },
-          "404" : {
-            "description" : "The specified resource was not found"
+          {
+            "name": "doc_id",
+            "in": "path",
+            "description": "Position of the document in the guided tour. This is not the ID of the document\n",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The successfully deleted document, associated to the guided tour.\n"
           },
-          "500" : {
-            "description" : "Unexpected server error (should not happen)"
+          "404": {
+            "description": "The specified resource was not found"
+          },
+          "500": {
+            "description": "Unexpected server error (should not happen)"
+          }
+        }
+      }
+    },
+    "/link": {
+      "get": {
+        "tags": [
+          "Links"
+        ],
+        "summary": "Retrieve the available target types for a link",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully get the possible target types",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "city_object"
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected server error (should not happen)"
+          }
+        }
+      }
+    },
+    "/link/{target_type}": {
+      "get": {
+        "tags": [
+          "Links"
+        ],
+        "summary": "Retrieve all links of the given type",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "target_type",
+            "in": "path",
+            "description": "Name of the target type. Same as the ones given by GET /link.",
+            "required": true,
+            "type": "string",
+            "x-example": "city_object"
+          },
+          {
+            "name": "source_id",
+            "in": "formData",
+            "description": "ID of the source document",
+            "required": false,
+            "type": "integer",
+            "x-example": 1
+          },
+          {
+            "name": "target_id",
+            "in": "formData",
+            "description": "ID of the target linkable object",
+            "required": false,
+            "type": "string",
+            "x-example": "city_object_234"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully get the links",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Link"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. Target type was probably incorrect."
+          },
+          "500": {
+            "description": "Unexpected server error (should not happen)"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Links"
+        ],
+        "summary": "Create a new link between a document and an object of the given type",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "target_type",
+            "in": "path",
+            "description": "Name of the target type. Same as the ones given by GET /link.",
+            "required": true,
+            "type": "string",
+            "x-example": "city_object"
+          },
+          {
+            "name": "source_id",
+            "in": "formData",
+            "description": "ID of the source document",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          },
+          {
+            "name": "target_id",
+            "in": "formData",
+            "description": "ID of the target linkable object",
+            "required": true,
+            "type": "string",
+            "x-example": "city_object_234"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully created the link",
+            "schema": {
+              "$ref": "#/definitions/Link"
+            }
+          },
+          "400": {
+            "description": "Bad request. Target type was probably incorrect."
+          },
+          "500": {
+            "description": "Unexpected server error (should not happen)"
           }
         }
       }
     }
   },
-  "securityDefinitions" : {
-    "Bearer" : {
-      "type" : "apiKey",
-      "name" : "Authorization",
-      "in" : "header"
+  "securityDefinitions": {
+    "Bearer": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
     }
   },
-  "definitions" : {
-    "TokenItem" : {
-      "type" : "object",
-      "properties" : {
-        "token" : {
-          "type" : "string",
-          "format" : "jwt",
-          "example" : "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VybmFtZSI6ImFkbWluIiwiZmlyc3ROYW1lIjoiQWRtaW4iLCJsYXN0TmFtZSI6IlVEViIsImVtYWlsIjoiYWRtaW5AdWR2LmZyIiwicG9zaXRpb24iOnsiTEVWRUxfTUlOIjoxLCJsYWJlbCI6ImFkbWluIiwiaWQiOjEsImNsZWFyYW5jZSI6WyJjb250cmlidXRvciIsInNvZnRNb2RlcmF0b3IiLCJtb2RlcmF0b3IiLCJhZG1pbiJdLCJMRVZFTF9NQVgiOjN9LCJleHAiOjE1NTg3NzcwMzYuMDM1MTczfQ.-6ns6_K-VpRlsqTrXbrV4shm8Oa0GJn3IfiR0LmLJoE"
+  "definitions": {
+    "TokenItem": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string",
+          "format": "jwt",
+          "example": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VybmFtZSI6ImFkbWluIiwiZmlyc3ROYW1lIjoiQWRtaW4iLCJsYXN0TmFtZSI6IlVEViIsImVtYWlsIjoiYWRtaW5AdWR2LmZyIiwicG9zaXRpb24iOnsiTEVWRUxfTUlOIjoxLCJsYWJlbCI6ImFkbWluIiwiaWQiOjEsImNsZWFyYW5jZSI6WyJjb250cmlidXRvciIsInNvZnRNb2RlcmF0b3IiLCJtb2RlcmF0b3IiLCJhZG1pbiJdLCJMRVZFTF9NQVgiOjN9LCJleHAiOjE1NTg3NzcwMzYuMDM1MTczfQ.-6ns6_K-VpRlsqTrXbrV4shm8Oa0GJn3IfiR0LmLJoE"
         }
       }
     },
-    "PositionItem" : {
-      "type" : "object",
-      "properties" : {
-        "id" : {
-          "type" : "integer",
-          "example" : 4
+    "PositionItem": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "example": 4
         },
-        "label" : {
-          "type" : "string",
-          "example" : "contributor"
+        "label": {
+          "type": "string",
+          "example": "contributor"
         }
       }
     },
-    "UserItem" : {
-      "type" : "object",
-      "properties" : {
-        "id" : {
-          "type" : "integer",
-          "example" : 1
+    "UserItem": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "example": 1
         },
-        "username" : {
-          "type" : "string",
-          "example" : "jdoe"
+        "username": {
+          "type": "string",
+          "example": "jdoe"
         },
-        "firstName" : {
-          "type" : "string",
-          "example" : "John"
+        "firstName": {
+          "type": "string",
+          "example": "John"
         },
-        "lastName" : {
-          "type" : "string",
-          "example" : "Doe"
+        "lastName": {
+          "type": "string",
+          "example": "Doe"
         },
-        "email" : {
-          "type" : "string",
-          "example" : "john.doe@example.com"
+        "email": {
+          "type": "string",
+          "example": "john.doe@example.com"
         },
-        "position" : {
-          "$ref" : "#/definitions/PositionItem"
+        "position": {
+          "$ref": "#/definitions/PositionItem"
         },
-        "position_id" : {
-          "type" : "integer",
-          "example" : 4
+        "position_id": {
+          "type": "integer",
+          "example": 4
         }
       }
     },
-    "MetaData" : {
-      "type" : "object",
-      "properties" : {
-        "title" : {
-          "type" : "string",
-          "example" : "Perrache"
+    "MetaData": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "example": "Perrache"
         },
-        "subject" : {
-          "type" : "string",
-          "example" : "Architecture"
+        "subject": {
+          "type": "string",
+          "example": "Architecture"
         },
-        "description" : {
-          "type" : "string",
-          "example" : "Une photo de la gare de Perrache"
+        "description": {
+          "type": "string",
+          "example": "Une photo de la gare de Perrache"
         },
-        "refDate" : {
-          "type" : "string",
-          "example" : "2019-03-15"
+        "refDate": {
+          "type": "string",
+          "example": "2019-03-15T00:00:00.000Z"
         },
-        "pubicationDate" : {
-          "type" : "string",
-          "example" : "2018-02-13"
+        "pubicationDate": {
+          "type": "string",
+          "example": "2018-02-13T00:00:00.000Z"
         },
-        "type" : {
-          "type" : "string",
-          "example" : "photo"
+        "type": {
+          "type": "string",
+          "example": "photo"
         }
       }
     },
-    "Visualization" : {
-      "type" : "object",
-      "properties" : {
-        "quaternionX" : {
-          "type" : "number",
-          "example" : 12.0
+    "Visualization": {
+      "type": "object",
+      "properties": {
+        "quaternionX": {
+          "type": "number",
+          "example": 12
         },
-        "quaternionY" : {
-          "type" : "number",
-          "example" : 23.0
+        "quaternionY": {
+          "type": "number",
+          "example": 23
         },
-        "quaternionZ" : {
-          "type" : "number",
-          "example" : 18.0
+        "quaternionZ": {
+          "type": "number",
+          "example": 18
         },
-        "quaternionW" : {
-          "type" : "number",
-          "example" : 0.0
+        "quaternionW": {
+          "type": "number",
+          "example": 0
         },
-        "positionX" : {
-          "type" : "number",
-          "example" : 17.0
+        "positionX": {
+          "type": "number",
+          "example": 17
         },
-        "positionY" : {
-          "type" : "number",
-          "example" : 3.0
+        "positionY": {
+          "type": "number",
+          "example": 3
         },
-        "positionZ" : {
-          "type" : "number",
-          "example" : 14.0
+        "positionZ": {
+          "type": "number",
+          "example": 14
         }
       }
     },
-    "ExtendedDocument" : {
-      "type" : "object",
-      "properties" : {
-        "id" : {
-          "type" : "number",
-          "example" : 1.0
+    "ExtendedDocument": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "example": 1
         },
-        "to_validate_doc" : {
-          "type" : "number",
-          "example" : 1.0
+        "to_validate_doc": {
+          "type": "number",
+          "example": 1
         },
-        "user_id" : {
-          "type" : "number",
-          "example" : 1.0
+        "user_id": {
+          "type": "number",
+          "example": 1
         },
-        "valid_doc" : {
-          "$ref" : "#/definitions/ExtendedDocument_valid_doc"
+        "valid_doc": {
+          "$ref": "#/definitions/ExtendedDocument_valid_doc"
         },
-        "metaData" : {
-          "$ref" : "#/definitions/MetaData"
+        "metaData": {
+          "$ref": "#/definitions/MetaData"
         },
-        "visualization" : {
-          "$ref" : "#/definitions/Visualization"
+        "visualization": {
+          "$ref": "#/definitions/Visualization"
         }
       }
     },
-    "GuidedTour" : {
-      "type" : "object",
-      "properties" : {
-        "id" : {
-          "type" : "number",
-          "example" : 2.0
+    "GuidedTour": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "example": 2
         },
-        "description" : {
-          "type" : "string",
-          "example" : "GuidedTour"
+        "description": {
+          "type": "string",
+          "example": "GuidedTour"
         },
-        "name" : {
-          "type" : "string",
-          "example" : "GuidedTour1"
+        "name": {
+          "type": "string",
+          "example": "GuidedTour1"
         },
-        "extendedDocs" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/GuidedTour_extendedDocs"
+        "extendedDocs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GuidedTour_extendedDocs"
           }
         }
       }
     },
-    "Comment" : {
-      "type" : "object",
-      "properties" : {
-        "id" : {
-          "type" : "number",
-          "example" : 2.0
+    "Comment": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "example": 2
         },
-        "document_id" : {
-          "type" : "number",
-          "example" : 1.0
+        "document_id": {
+          "type": "number",
+          "example": 1
         },
-        "user_id" : {
-          "type" : "number",
-          "example" : 3.0
+        "user_id": {
+          "type": "number",
+          "example": 3
         },
-        "description" : {
-          "type" : "string",
-          "example" : "This is a comment"
+        "description": {
+          "type": "string",
+          "example": "This is a comment"
         }
       }
     },
-    "ExtendedDocument_valid_doc" : {
-      "properties" : {
-        "is_valid" : {
-          "type" : "number",
-          "example" : 1.0
+    "ExtendedDocument_valid_doc": {
+      "properties": {
+        "is_valid": {
+          "type": "number",
+          "example": 1
         }
       }
     },
-    "GuidedTour_extendedDocs" : {
-      "properties" : {
-        "id" : {
-          "type" : "string",
-          "example" : "1"
+    "GuidedTour_extendedDocs": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "example": "1"
         },
-        "text1" : {
-          "type" : "string",
-          "example" : "text1"
+        "text1": {
+          "type": "string",
+          "example": "text1"
         },
-        "text2" : {
-          "type" : "string",
-          "example" : "text2"
+        "text2": {
+          "type": "string",
+          "example": "text2"
         },
-        "title" : {
-          "type" : "string",
-          "example" : "title"
+        "title": {
+          "type": "string",
+          "example": "title"
         },
-        "document" : {
-          "$ref" : "#/definitions/ExtendedDocument"
+        "document": {
+          "$ref": "#/definitions/ExtendedDocument"
+        }
+      }
+    },
+    "Link": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "example": 1
+        },
+        "source_id": {
+          "type": "integer",
+          "example": 1
+        },
+        "target_id": {
+          "type": "string",
+          "example": "city_object_23"
         }
       }
     }
   },
-  "responses" : {
-    "BadRequest" : {
-      "description" : "Request is malformed (a mandatory field is missing)"
+  "responses": {
+    "BadRequest": {
+      "description": "Request is malformed (a mandatory field is missing)"
     },
-    "AuthenticationFailed" : {
-      "description" : "Authentication is needed to perform the request"
+    "AuthenticationFailed": {
+      "description": "Authentication is needed to perform the request"
     },
-    "Forbidden" : {
-      "description" : "The user does not has sufficient privilege to perform the request\n"
+    "Forbidden": {
+      "description": "The user does not has sufficient privilege to perform the request\n"
     },
-    "NotFound" : {
-      "description" : "The specified resource was not found"
+    "NotFound": {
+      "description": "The specified resource was not found"
     },
-    "IntegrityError" : {
-      "description" : "Unprocessable entity (invalid field, duplicate item)\n"
+    "IntegrityError": {
+      "description": "Unprocessable entity (invalid field, duplicate item)\n"
     },
-    "FileFormatError" : {
-      "description" : "The file has an incorrect format\n"
+    "FileFormatError": {
+      "description": "The file has an incorrect format\n"
     },
-    "ServerError" : {
-      "description" : "Unexpected server error (should not happen)"
+    "ServerError": {
+      "description": "Unexpected server error (should not happen)"
     }
   }
 }

--- a/API_Enhanced_City/doc/OpenAPI2/swagger.yaml
+++ b/API_Enhanced_City/doc/OpenAPI2/swagger.yaml
@@ -1,11 +1,9 @@
----
 swagger: "2.0"
 info:
   description: API used to manage the extended documents in UDV Server.
   version: 1.0.0
   title: UDV-Server API$
-host: virtserver.swaggerhub.com
-basePath: /Crejak/UDV-Server/1.0.0
+host: localhost:5000
 tags:
 - name: Users
   description: User account management
@@ -23,6 +21,8 @@ tags:
   description: Guided tour management
 - name: Guided tour documents
   description: Management of documents inside a guided tour
+- name: Links
+  description: Management of links between documents and likable objects
 schemes:
 - https
 paths:
@@ -860,7 +860,7 @@ paths:
         required: true
         type: integer
         x-example: 1
-      - name: user_id
+      - name: doc_id
         in: formData
         description: ID of the document to add
         required: true
@@ -944,6 +944,94 @@ paths:
             The successfully deleted document, associated to the guided tour.
         404:
           description: The specified resource was not found
+        500:
+          description: Unexpected server error (should not happen)
+  /link:
+    get:
+      tags:
+      - Links
+      summary: Retrieve the available target types for a link
+      consumes:
+      - multipart/form-data
+      responses:
+        200:
+          description: Successfully get the possible target types
+          schema:
+            type: array
+            items:
+              type: string
+              example: 'city_object'
+        500:
+          description: Unexpected server error (should not happen)
+  /link/{target_type}:
+    get:
+      tags:
+      - Links
+      summary: Retrieve all links of the given type
+      consumes:
+      - multipart/form-data
+      parameters:
+      - name: target_type
+        in: path
+        description: Name of the target type. Same as the ones given by GET /link.
+        required: true
+        type: string
+        x-example: 'city_object'
+      - name: source_id
+        in: formData
+        description: ID of the source document
+        required: false
+        type: integer
+        x-example: 1
+      - name: target_id
+        in: formData
+        description: ID of the target linkable object
+        required: false
+        type: string
+        x-example: 'city_object_234'
+      responses:
+        200:
+          description: Successfully get the links
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Link'
+        400:
+          description: Bad request. Target type was probably incorrect.
+        500:
+          description: Unexpected server error (should not happen)
+    post:
+      tags:
+      - Links
+      summary: Create a new link between a document and an object of the given type
+      consumes:
+      - multipart/form-data
+      parameters:
+      - name: target_type
+        in: path
+        description: Name of the target type. Same as the ones given by GET /link.
+        required: true
+        type: string
+        x-example: 'city_object'
+      - name: source_id
+        in: formData
+        description: ID of the source document
+        required: true
+        type: integer
+        x-example: 1
+      - name: target_id
+        in: formData
+        description: ID of the target linkable object
+        required: true
+        type: string
+        x-example: 'city_object_234'
+      responses:
+        201:
+          description: Successfully created the link
+          schema:
+            $ref: '#/definitions/Link'
+        400:
+          description: Bad request. Target type was probably incorrect.
         500:
           description: Unexpected server error (should not happen)
 securityDefinitions:
@@ -1106,6 +1194,17 @@ definitions:
         example: title
       document:
         $ref: '#/definitions/ExtendedDocument'
+  Link:
+    properties:
+      id:
+        type: integer
+        example: 1
+      source_id:
+        type: integer
+        example: 1
+      target_id:
+        type: string
+        example: "city_object_23"
 responses:
   BadRequest:
     description: Request is malformed (a mandatory field is missing)

--- a/API_Enhanced_City/entities/Document.py
+++ b/API_Enhanced_City/entities/Document.py
@@ -9,7 +9,7 @@ from util.db_config import Base
 from entities.Entity import Entity
 
 from entities.Visualisation import Visualisation
-from entities.Position import Position, LEVEL_MIN
+from entities.UserRole import UserRole, LEVEL_MIN
 from entities.ValidationStatus import ValidationStatus, Status
 
 
@@ -68,8 +68,8 @@ class Document(Entity, Base):
 
     @staticmethod
     def is_allowed(auth_info):
-        role = auth_info['position']['label']
-        level = Position.get_clearance_level(role)
+        role = auth_info['role']['label']
+        level = UserRole.get_clearance_level(role)
         return level > LEVEL_MIN
 
     def owner_id(self):

--- a/API_Enhanced_City/entities/LinkCityObject.py
+++ b/API_Enhanced_City/entities/LinkCityObject.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# coding: utf8
+
+from sqlalchemy import Column, Integer, String
+from sqlalchemy import ForeignKey
+
+from util.db_config import Base
+from entities.Entity import Entity
+
+
+class LinkCityObject(Base, Entity):
+    """
+    Represents a link between a document and a city object.
+    """
+    __tablename__ = "link_city_object"
+
+    id = Column(Integer, primary_key=True)
+    source_id = Column(Integer, ForeignKey('document.id'), nullable=False)
+    target_id = Column(String, nullable=False)
+
+    def __init__(self, source_id, target_id):
+        """
+        Creates a link between a document and a city object.
+
+        :param int source_id: ID of the source document.
+        :param str target_id: ID of the target city object.
+        """
+        self.source_id = source_id
+        self.target_id = target_id
+        # @todo Check if target_id corresponds to a existing city object

--- a/API_Enhanced_City/entities/User.py
+++ b/API_Enhanced_City/entities/User.py
@@ -11,7 +11,7 @@ from util.Exception import UnprocessableEntity
 
 from entities.Entity import Entity
 
-from entities.Position import Position, LEVEL_MAX
+from entities.UserRole import UserRole, LEVEL_MAX
 
 
 class User(Entity, Base):
@@ -24,9 +24,9 @@ class User(Entity, Base):
     lastName = Column(String, nullable=False)
     email = Column(String, nullable=False, unique=True)
 
-    position_id = Column(Integer, ForeignKey(Position.id))
-    position = relationship(Position,
-                            uselist=False)
+    role_id = Column(Integer, ForeignKey(UserRole.id))
+    role = relationship(UserRole,
+                        uselist=False)
 
     documentUser = relationship('DocumentUser',
                                 cascade="all, delete-orphan")
@@ -47,13 +47,13 @@ class User(Entity, Base):
             self.password = encrypt(new_values['password'])
         return self
 
-    def set_position(self, position):
-        self.position = position
-        self.position_id = position.id
+    def set_role(self, position):
+        self.role = position
+        self.role_id = position.id
 
     @staticmethod
     def is_admin(attributes):
-        level = Position.get_clearance_level(attributes['role'])
+        level = UserRole.get_clearance_level(attributes['role'])
         if level is None:
             raise UnprocessableEntity(f'Unknown role : {attributes["role"]}')
         return level == LEVEL_MAX

--- a/API_Enhanced_City/entities/UserRole.py
+++ b/API_Enhanced_City/entities/UserRole.py
@@ -12,8 +12,8 @@ LEVEL_MIN = 1
 LEVEL_MAX = 3
 
 
-class Position(Entity, Base):
-    __tablename__ = "position"
+class UserRole(Entity, Base):
+    __tablename__ = "user_role"
 
     id = Column(Integer, primary_key=True)
     label = Column(String)

--- a/API_Enhanced_City/test/test_archive.py
+++ b/API_Enhanced_City/test/test_archive.py
@@ -48,7 +48,7 @@ class TestArchive:
             'description': 'a description',
             'file': '1.gif',
             'user_id': 1,
-            "position": {
+            "role": {
                 'label' : 'admin'
             }
         }, {
@@ -86,7 +86,7 @@ class TestArchive:
         }
         assert expected_response == DocController.update_document({
             'user_id': 1,
-            "position": {
+            "role": {
                 'label': 'admin'
             }},
             1,
@@ -124,7 +124,7 @@ class TestArchive:
         }
         assert expected_response == DocController.update_document({
             'user_id': 1,
-            'position': {
+            'role': {
                 'label': 'admin'
             }
         }, 1, {
@@ -137,7 +137,7 @@ class TestArchive:
         expected_response = None
         assert expected_response == DocController.delete_documents(1, {
                 'user_id' : 1,
-                "position": {
+                "role": {
                     'label' : 'admin'
                 }
             })

--- a/API_Enhanced_City/test/test_comment.py
+++ b/API_Enhanced_City/test/test_comment.py
@@ -66,7 +66,7 @@ class TestComment:
             'description': 'a description',
             'file': '1.gif',
             'user_id': 1,
-            "position": {
+            "role": {
                 'label': 'admin'
             }
         }, {
@@ -113,7 +113,7 @@ class TestComment:
         assert expected_response == CommentController.update_comment(1, {
             'id': 1,
             'user_id': 1,
-            "position": {
+            "role": {
                 'label': 'admin'
             },
             'description': 'ok_1'
@@ -130,7 +130,7 @@ class TestComment:
         }
         assert expected_response == CommentController.delete_comment(2, {
             'user_id': 1,
-            "position": {
+            "role": {
                 'label': 'admin'
             }
         })

--- a/API_Enhanced_City/test/test_document.py
+++ b/API_Enhanced_City/test/test_document.py
@@ -69,7 +69,7 @@ class TestDocument:
             'type': 'type',
             'description': 'a description',
             'file': '1.gif',
-            'position': {'label': 'admin'}
+            'role': {'label': 'admin'}
         }, {
             'user_id': 1
         })
@@ -112,7 +112,7 @@ class TestDocument:
             'description': 'a description',
             'file': '2.gif',
             'refDate': FAKE_REF_DATE,
-            'position': {'label': 'admin'}
+            'role': {'label': 'admin'}
         }, {
             'user_id': 2
         })
@@ -129,7 +129,7 @@ class TestDocument:
             'refDate': FAKE_REF_DATE,
             'description': 'an other description',
             'file': '3.png',
-            'position': {'label': 'contributor'}
+            'role': {'label': 'contributor'}
         }, {
             'user_id': 2
         }) is not None
@@ -146,7 +146,7 @@ class TestDocument:
             'refDate': FAKE_REF_DATE,
             'description': 'details',
             'file': '3.png',
-            'position': {'label': 'admin'}
+            'role': {'label': 'admin'}
         }, {
             'user_id': 1
         }) is not None
@@ -166,7 +166,7 @@ class TestDocument:
         with pytest.raises(AuthError):
             DocController.validate_document(2, {
                 'user_id': 2,
-                'position': {'label': 'contributor'}
+                'role': {'label': 'contributor'}
             }, {
                 'user_id': 2
             })
@@ -176,7 +176,7 @@ class TestDocument:
         with pytest.raises(sqlalchemy.orm.exc.NoResultFound):
             DocController.validate_document(7, {
                 'user_id': 1,
-                'position': {'label': 'admin'}
+                'role': {'label': 'admin'}
             }, {
                 'user_id': 1
             })
@@ -202,7 +202,7 @@ class TestDocument:
         print('Get documents to validate as an admin')
         response = DocController.get_documents_to_validate({
             'user_id': 3,
-            'position': {'label': 'admin'}
+            'role': {'label': 'admin'}
         })
         assert len(response) == 1
         assert response[0]['id'] == 3
@@ -211,7 +211,7 @@ class TestDocument:
         print('Get documents to validate as a contributor')
         response = DocController.get_documents_to_validate({
             'user_id': 3,
-            'position': {'label': 'admin'}
+            'role': {'label': 'admin'}
         })
         assert len(response) == 1
         assert response[0]['id'] == 3
@@ -231,7 +231,7 @@ class TestDocument:
             DocController.update_document({
                 'user_id': 2,
                 'user_position': 'contributor',
-                'position': {'label': 'contributor'}
+                'role': {'label': 'contributor'}
             }, 1, {
                 'positionX': 12,
                 'description': 'description of a document'
@@ -242,7 +242,7 @@ class TestDocument:
         response = DocController.update_document({
             'user_id': 2,
             'user_position': 'admin',
-            'position': {'label': 'admin'}
+            'role': {'label': 'admin'}
         }, 1, {
             'positionX': 12,
             'description': 'another description'
@@ -256,7 +256,7 @@ class TestDocument:
             DocController.update_document({
                 'user_position': 'admin',
                 'user_id': 2,
-                'position': {'label': 'admin'}
+                'role': {'label': 'admin'}
             }, -1, {
                 'positionX': 12,
                 'description': 'another description'
@@ -267,7 +267,7 @@ class TestDocument:
         with pytest.raises(AuthError):
             DocController.delete_documents(4, {
                 'user_id': 2,
-                'position': {'label': 'contributor'}
+                'role': {'label': 'contributor'}
             })
 
     def test_delete_document_as_admin(self):
@@ -275,7 +275,7 @@ class TestDocument:
         try:
             DocController.delete_documents(4, {
                 'user_id': 1,
-                'position': {'label': 'admin'}
+                'role': {'label': 'admin'}
             })
         except Exception as e:
             print(e)

--- a/API_Enhanced_City/test/test_guided_tour.py
+++ b/API_Enhanced_City/test/test_guided_tour.py
@@ -79,7 +79,7 @@ class TestGuidedTour:
             "description": "a description",
             "file": "1.gif",
             'user_id': 1,
-            'position': {'label': 'admin'}
+            'role': {'label': 'admin'}
         }, {
             'user_id': 1
         })
@@ -90,7 +90,7 @@ class TestGuidedTour:
             "description": "a description",
             "file": "1.gif",
             'user_id': 1,
-            'position': {'label': 'admin'}
+            'role': {'label': 'admin'}
         }, {
             'user_id': 1
         })

--- a/API_Enhanced_City/test/test_position.py
+++ b/API_Enhanced_City/test/test_position.py
@@ -2,7 +2,7 @@
 # coding: utf8
 
 from controller.Controller import Controller
-from controller.PositionController import PositionController
+from controller.UserRoleController import UserRoleController
 
 
 class TestPosition:
@@ -11,7 +11,7 @@ class TestPosition:
         Controller.recreate_tables()
         print("all positions")
         expected_response = 4
-        assert expected_response == len(PositionController.get_positions())
+        assert expected_response == len(UserRoleController.get_roles())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added basic link management in the back-end :

- New entity called `LinkCityObject` representing a link between a document and a city object
- New controller that allows to create and get links of a specific type (the only supported type yet is City Object)
- New API endpoints to access the links :
  - `/link` to get all supported types (for now, just `city_object`)
  - `/link/<type>` (GET and POST) to get/create links of a supported type (eg. `/link/city_object`)
- API documentation up to date.

Other changes :

- Renamed entity `Position` to `UserRole` which is less ambiguous
- Added a script to clear the database (it contains 2 commands, `rm postgres-data` and `rm upload/*`). The goal is to avoid forgetting to delete the image files.