### PR TITLE
Changed GET link filters from form to args

### DIFF
--- a/API_Enhanced_City/api/web_api.py
+++ b/API_Enhanced_City/api/web_api.py
@@ -373,7 +373,7 @@ def get_links(target_type_name):
         'city_object'.
     :return: The retrieved links
     """
-    filters = request.form
+    filters = request.args
     links = LinkController.get_links(target_type_name, filters)
     return ResponseOK(links)
 


### PR DESCRIPTION
Changed the `GET /link/<link_type>` request to take filter arguments from request parameters, instead of body.

For example, instead of doing `GET /link/city_object` with `source_id=1` as a form data body, the new route takes directly the parameters in the url : `GET /link/city_object?source_id=1`.

The reason to change this behaviour is because HTTP GET request should not have a body. Actually, they _may_ have one but it should be ignored by the server. So the previous way of filtering the result was in fact not working correctly (that's what I found out while implementing the client-side requests). The prefered way of filtering HTTP GET results is by passing filters to the URL.

Reference : https://stackoverflow.com/questions/978061/http-get-with-request-body