### PR TITLE
Added centroid to link_city_object + added delete link route

### DIFF
--- a/API_Enhanced_City/api/web_api.py
+++ b/API_Enhanced_City/api/web_api.py
@@ -367,7 +367,9 @@ def get_link_target_types():
 @format_response
 def get_links(target_type_name):
     """
-    Retrieves links between documents and the specified target type.
+    Retrieves links between documents and the specified target type. Filtering
+    can be performed by passing URL parameters corresponding to fields of the
+    link object (`source_id` and `target_id` are always supported).
 
     :param str target_type_name: Name of the target type. Accepted names are :
         'city_object'.
@@ -383,6 +385,7 @@ def get_links(target_type_name):
 def create_link(target_type_name):
     """
     Creates a new link between the source document and the specified target.
+    Properties must be supplied in form data.
 
     :param target_type_name: Name of the target type. Accepted names are :
         'city_object'.
@@ -392,8 +395,22 @@ def create_link(target_type_name):
     target_id = request.form.get('target_id')
     if source_id is None or target_id is None:
         raise BadRequest('Missing source and/or target id')
-    link = LinkController.create_link(target_type_name, source_id, target_id)
+    link = LinkController.create_link(target_type_name, request.form)
     return ResponseCreated(link)
+
+
+@app.route('/link/<target_type_name>/<int:link_id>', methods=['DELETE'])
+@format_response
+def delete_link(target_type_name, link_id):
+    """
+    Deletes the link of the specified target type with the specified ID.
+
+    :param target_type_name: The target type of the link.
+    :param link_id: The ID of the link.
+    :return: The deleted link.
+    """
+    link = LinkController.delete_link(target_type_name, link_id)
+    return ResponseOK(link)
 
 
 if __name__ == '__main__':

--- a/API_Enhanced_City/doc/OpenAPI2/swagger.json
+++ b/API_Enhanced_City/doc/OpenAPI2/swagger.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "title": "UDV-Server API$"
   },
-  "host": "localhost:5000",
+  "host": "localhost:1525",
   "tags": [
     {
       "name": "Users",
@@ -1441,9 +1441,6 @@
           "Links"
         ],
         "summary": "Retrieve all links of the given type",
-        "consumes": [
-          "multipart/form-data"
-        ],
         "parameters": [
           {
             "name": "target_type",
@@ -1455,7 +1452,7 @@
           },
           {
             "name": "source_id",
-            "in": "formData",
+            "in": "query",
             "description": "ID of the source document",
             "required": false,
             "type": "integer",
@@ -1463,11 +1460,11 @@
           },
           {
             "name": "target_id",
-            "in": "formData",
+            "in": "query",
             "description": "ID of the target linkable object",
             "required": false,
             "type": "string",
-            "x-example": "city_object_234"
+            "x-example": "345423"
           }
         ],
         "responses": {
@@ -1531,6 +1528,49 @@
           },
           "400": {
             "description": "Bad request. Target type was probably incorrect."
+          },
+          "500": {
+            "description": "Unexpected server error (should not happen)"
+          }
+        }
+      }
+    },
+    "/link/{target_type}/{link_id}": {
+      "delete": {
+        "tags": [
+          "Links"
+        ],
+        "summary": "Deletes an existing link from its target type and ID",
+        "parameters": [
+          {
+            "name": "target_type",
+            "in": "path",
+            "description": "Name of the target type. Same as the ones given by GET /link",
+            "required": true,
+            "type": "string",
+            "x-example": "city_object"
+          },
+          {
+            "name": "link_id",
+            "in": "path",
+            "description": "ID of the link object",
+            "required": true,
+            "type": "integer",
+            "x-example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted the link",
+            "schema": {
+              "$ref": "#/definitions/Link"
+            }
+          },
+          "400": {
+            "description": "Bad request. Target type was probably incorrect."
+          },
+          "404": {
+            "description": "Link was not found"
           },
           "500": {
             "description": "Unexpected server error (should not happen)"
@@ -1777,7 +1817,7 @@
         },
         "target_id": {
           "type": "string",
-          "example": "city_object_23"
+          "example": "543548"
         }
       }
     }

--- a/API_Enhanced_City/doc/OpenAPI2/swagger.yaml
+++ b/API_Enhanced_City/doc/OpenAPI2/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: API used to manage the extended documents in UDV Server.
   version: 1.0.0
   title: UDV-Server API$
-host: localhost:5000
+host: localhost:1525
 tags:
 - name: Users
   description: User account management
@@ -968,8 +968,6 @@ paths:
       tags:
       - Links
       summary: Retrieve all links of the given type
-      consumes:
-      - multipart/form-data
       parameters:
       - name: target_type
         in: path
@@ -978,17 +976,17 @@ paths:
         type: string
         x-example: 'city_object'
       - name: source_id
-        in: formData
+        in: query
         description: ID of the source document
         required: false
         type: integer
         x-example: 1
       - name: target_id
-        in: formData
+        in: query
         description: ID of the target linkable object
         required: false
         type: string
-        x-example: 'city_object_234'
+        x-example: '345423'
       responses:
         200:
           description: Successfully get the links
@@ -1032,6 +1030,35 @@ paths:
             $ref: '#/definitions/Link'
         400:
           description: Bad request. Target type was probably incorrect.
+        500:
+          description: Unexpected server error (should not happen)
+  /link/{target_type}/{link_id}:
+    delete:
+      tags:
+      - Links
+      summary: Deletes an existing link from its target type and ID
+      parameters:
+      - name: target_type
+        in: path
+        description: Name of the target type. Same as the ones given by GET /link
+        required: true
+        type: string
+        x-example: 'city_object'
+      - name: link_id
+        in: path
+        description: ID of the link object
+        required: true
+        type: integer
+        x-example: 1
+      responses:
+        200:
+          description: Successfully deleted the link
+          schema:
+            $ref: '#/definitions/Link'
+        400:
+          description: Bad request. Target type was probably incorrect.
+        404:
+          description: Link was not found
         500:
           description: Unexpected server error (should not happen)
 securityDefinitions:
@@ -1204,7 +1231,7 @@ definitions:
         example: 1
       target_id:
         type: string
-        example: "city_object_23"
+        example: "543548"
 responses:
   BadRequest:
     description: Request is malformed (a mandatory field is missing)

--- a/API_Enhanced_City/entities/LinkCityObject.py
+++ b/API_Enhanced_City/entities/LinkCityObject.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # coding: utf8
 
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, Float
 from sqlalchemy import ForeignKey
 
 from util.db_config import Base
@@ -17,8 +17,11 @@ class LinkCityObject(Base, Entity):
     id = Column(Integer, primary_key=True)
     source_id = Column(Integer, ForeignKey('document.id'), nullable=False)
     target_id = Column(String, nullable=False)
+    centroid_x = Column(Float)
+    centroid_y = Column(Float)
+    centroid_z = Column(Float)
 
-    def __init__(self, source_id, target_id):
+    def __init__(self, source_id, target_id, centroid_x, centroid_y, centroid_z):
         """
         Creates a link between a document and a city object.
 
@@ -27,4 +30,7 @@ class LinkCityObject(Base, Entity):
         """
         self.source_id = source_id
         self.target_id = target_id
+        self.centroid_x = centroid_x
+        self.centroid_y = centroid_y
+        self.centroid_z = centroid_z
         # @todo Check if target_id corresponds to a existing city object


### PR DESCRIPTION
- Added centroid coordinates in the LinkCityObject entity. This allow to store information about the location of the city object, without needing to read the 3DTiles data.
- Added deletion route for links (`DELETE /link/<link_type>/<link_id>`)
- A bit of refactoring in the existing LinkController (to support attributes specific to some link types, like the centroid for links with city objects)