### PR TITLE
Citygml2stripper

### DIFF
--- a/Utils/CityGMLBuildingBlender/CityGMLBuildingBlender.py
+++ b/Utils/CityGMLBuildingBlender/CityGMLBuildingBlender.py
@@ -1,21 +1,16 @@
 import argparse
-import os
 import lxml.etree as ET
 
 def ParseCommandLine():
     # arg parse
     descr = '''A small utility that extracts all the buildings from a 
-               set of CityGML (XML) files folder, blends them and 
-               serializes the result in a new CityGML (XML) file.'''
+               set of CityGML (XML) files, blends them and serializes the
+               result in a new CityGML (XML) file.'''
     parser = argparse.ArgumentParser(description=descr)
-    parser.add_argument('--inputFiles',
+    parser.add_argument('--input',
                         nargs='+',
                         type=str,
                         help='CityGML input files')
-    parser.add_argument('--inputFolder',
-                        nargs='+',
-                        type=str,
-                        help='Input folder holding CityGML files')
     parser.add_argument('--output',
                         nargs='+',
                         default='output.gml',
@@ -27,8 +22,6 @@ def ParseCommandLine():
 def parse_and_simplify(file_path_name, name_space):
     parser = ET.XMLParser(remove_comments=True)
     result = ET.parse(file_path_name, parser)
-    # Remove textures coordinates (currently not used by our
-    # algorithms)
     appearance = result.find("//app:appearanceMember",
                              namespaces=name_space)
     if appearance is not None:
@@ -39,20 +32,8 @@ if __name__ == '__main__':
     cli_args = ParseCommandLine()
     name_space = {None: 'http://www.opengis.net/citygml/1.0',
                   'app': 'http://www.opengis.net/citygml/appearance/1.0'}
-    # Parse and simplify inputFiles
-    inputs = [parse_and_simplify(filename, name_space)
-              for filename in cli_args.inputFiles]
-    # Get gml files from input folder
-    # r = root, d = directories, f = files
-    input_folder = cli_args.inputFolder[0]
-    input_folder_files = []
-    for r, d, f in os.walk(input_folder):
-        for filename in f:
-            if filename.endswith('.gml'):
-                input_folder_files.append(input_folder + filename)
-
-    inputs = inputs + [parse_and_simplify(filename, name_space)
-                       for filename in input_folder_files]
+    inputs = [ parse_and_simplify(filename, name_space)
+               for filename in cli_args.input]
     # We recycle the first parsed input to become the output
     output = inputs[0]
 
@@ -60,4 +41,3 @@ if __name__ == '__main__':
                                                 namespaces=name_space):
         output.getroot().append(city_object_member)
     output.write(cli_args.output[0])
-

--- a/Utils/CityGMLBuildingBlender/Readme.md
+++ b/Utils/CityGMLBuildingBlender/Readme.md
@@ -12,15 +12,5 @@ $ . venv/bin/activate
 ## Usages
 * With input files:
 ```bash
-(venv)$ python CityGMLBuildingBlender.py --inputFiles filename_1.gml filename_2.gml <...filename_n.gml...> --output output.gml
-```
-
-* With input folder:
-```bash
-(venv)$ python CityGMLBuildingBlender.py --inputFolder ./CityGMLFiles --output output.gml
-```
-
-* Mixing input files and folder:
-```bash
-(venv)$ python CityGMLBuildingBlender.py --inputFiles filename_1.gml filename_2.gml <...filename_n.gml...> --inputFolder ./CityGMLFiles --output output.gml
+(venv)$ python CityGMLBuildingBlender.py --input filename_1.gml filename_2.gml <...filename_n.gml...> --output output.gml
 ```


### PR DESCRIPTION
Add a tool that takes a CityGML file, removes the elements in the appearance (texture coordinates) and in the generic (generic attributes) namespaces and writes out the result.

This small utility is currently used in the objective to be able to compare currently produced 3D Tiles (without appearances and generic attributs)  with corresponding CityGML files. 